### PR TITLE
Remove Gradle plugin instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,3 @@ srcclr activate
 srcclr scan --url https://github.com/srcclr/example-java-gradle
 ```
 
-## With SourceClear's Gradle Plugin
-```
-git clone https://github.com/srcclr/example-java-gradle
-cd example-java-gradle
-git checkout gradle-plugin-5.5.1 // the plugin is already setup in build.gradle in this branch
-SRCCLR_API_TOKEN=<yourSourceClearToken> ./gradlew clean build srcclr
-```
-
-
-Documenting more of why gradle is awesome here!


### PR DESCRIPTION
Removed instructions for SourceClear's Gradle plugin and added a note about documenting Gradle.